### PR TITLE
build: rename default branch from main to master

### DIFF
--- a/.claude/commands/create-pr.md
+++ b/.claude/commands/create-pr.md
@@ -9,7 +9,7 @@ You are about to create a pull request. Work through these two tasks in order.
 
 Run `date +%Y-%m-%d` to get today's date and `date +%H%M` for the current time.
 
-Run `git log main..HEAD --oneline` to see all commits on this branch. Run `git diff main...HEAD
+Run `git log master..HEAD --oneline` to see all commits on this branch. Run `git diff master...HEAD
 --stat` to see which files changed. Use this to understand the full scope of what the PR contains.
 
 The daily devlog file is `docs/devlog/YYYY-MM-DD.md`. Check whether it already exists:
@@ -61,7 +61,7 @@ git commit -m "docs: add diary entry for PR"
 
 ## Task 2 — Create the Pull Request
 
-Run `git log main..HEAD --oneline` to review the commits. Draft a PR title (under 70 characters)
+Run `git log master..HEAD --oneline` to review the commits. Draft a PR title (under 70 characters)
 and body. The body should follow this format:
 
 ```

--- a/.github/README.md
+++ b/.github/README.md
@@ -36,12 +36,12 @@ checks locally, writes the devlog entry, and then opens the PR.
 
 ### `ci.yml`
 
-Runs on every push and pull request to `main`. Executes `npm run lint`,
+Runs on every push and pull request to `master`. Executes `npm run lint`,
 `npm run format:check`, and `npm run test` in a Node.js 20 environment. PRs cannot merge
 unless all three checks pass.
 
 ### `deploy.yml`
 
-Production deployment pipeline. Triggered on push to `main` after CI passes. Builds the
+Production deployment pipeline. Triggered on push to `master` after CI passes. Builds the
 Vite client (`npm run build`) and deploys the server and built assets to the DigitalOcean
 Droplet via PM2 (`ecosystem.config.cjs`).

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,7 +3,7 @@ name: Deploy
 on:
   push:
     branches:
-      - main
+      - master
 
 jobs:
   deploy:
@@ -22,7 +22,7 @@ jobs:
             cd /opt/lob-online
 
             echo "→ Pulling latest code..."
-            git pull origin main
+            git pull origin master
 
             echo "→ Installing dependencies..."
             npm ci --omit=dev
@@ -41,4 +41,4 @@ jobs:
 #   DO_SSH_KEY     — Private SSH key with access to the Droplet
 #
 # Branch protection: configure GitHub to require CI to pass before
-# allowing merge to main, ensuring deploy only runs on green code.
+# allowing merge to master, ensuring deploy only runs on green code.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,7 +55,7 @@ See the **Coding Standards** section in `CLAUDE.md` for the full style guide.
 
 ## Branch and PR workflow
 
-1. Branch off `main`. Branch name prefix convention:
+1. Branch off `master`. Branch name prefix convention:
    - `feat/` — new feature
    - `fix/` — bug fix
    - `docs/` — documentation only
@@ -69,7 +69,7 @@ See the **Coding Standards** section in `CLAUDE.md` for the full style guide.
 3. Open a pull request using the `/create-pr` skill, which runs CI checks locally, writes the
    devlog entry, and calls `gh pr create`. Do not use `gh pr create` directly.
 
-4. PRs require CI to pass. Squash-merge is preferred to keep `main` history clean.
+4. PRs require CI to pass. Squash-merge is preferred to keep `master` history clean.
 
 ## Commit messages
 

--- a/docs/high-level-design-prompt.md
+++ b/docs/high-level-design-prompt.md
@@ -86,7 +86,7 @@ Documentation and scoping only. No code exists. All source material (rulebooks, 
 | Reverse proxy      | nginx — terminates HTTPS, proxies to Node process                                 |
 | TLS                | Let's Encrypt via Certbot (auto-renewing)                                         |
 | Process management | PM2 — keeps Node process alive, handles restarts, log management                  |
-| CI/CD              | GitHub Actions — lint + test on every PR; deploy to Droplet on merge to `main`    |
+| CI/CD              | GitHub Actions — lint + test on every PR; deploy to Droplet on merge to `master`  |
 | Environment config | `dotenv` locally; environment variables set directly on the Droplet in production |
 | Request logging    | `morgan` (dev) / structured JSON log in production                                |
 
@@ -351,7 +351,7 @@ Design the full DevOps pipeline for deploying to a DigitalOcean Droplet.
 - Build: `vite build` (catch build errors before merge)
 - Show the complete `.github/workflows/ci.yml`
 
-**GitHub Actions — CD (runs on merge to `main`):**
+**GitHub Actions — CD (runs on merge to `master`):**
 
 - SSH into the Droplet
 - Pull latest code (`git pull`)


### PR DESCRIPTION
## Summary
- Renames remote default branch from `main` to `master`
- Updates branch protection ruleset to target `refs/heads/master`
- Updates all `main` branch references in workflows, commands, and docs

## Changes
- `.github/workflows/deploy.yml` — trigger branch and git pull target
- `.claude/commands/create-pr.md` — `git log` base branch references
- `CONTRIBUTING.md` — branch workflow prose
- `.github/README.md` — workflow description prose
- `docs/high-level-design-prompt.md` — CI/CD table and CD description

## Test plan
- [ ] lint passes
- [ ] format:check passes
- [ ] tests pass
- [ ] GitHub default branch shows `master`
- [ ] Remote `main` branch is gone
- [ ] Deploy workflow triggers on push to `master`

🤖 Generated with [Claude Code](https://claude.com/claude-code)