### PR TITLE
docs(tech-debt): resolve debt items #146 #147 (PR #148)

### DIFF
--- a/docs/tech-debt/report.md
+++ b/docs/tech-debt/report.md
@@ -1,6 +1,6 @@
 # Technical Debt Report — lob-online
 
-_Last updated: 2026-03-19 after PR #145._
+_Last updated: 2026-03-19 after PR #148._
 
 ---
 
@@ -8,10 +8,10 @@ _Last updated: 2026-03-19 after PR #145._
 
 | Metric                           | Value                                                                     |
 | -------------------------------- | ------------------------------------------------------------------------- |
-| Open debt items                  | 7                                                                         |
-| Cumulative debt score (net open) | 17                                                                        |
+| Open debt items                  | 5                                                                         |
+| Cumulative debt score (net open) | 12                                                                        |
 | Highest-risk item                | Introduce `onHexUpdateBatch` to unify dual mutation paths (#124, score 3) |
-| PRs tracked                      | 27                                                                        |
+| PRs tracked                      | 28                                                                        |
 
 ---
 
@@ -46,6 +46,8 @@ _Last updated: 2026-03-19 after PR #145._
 | 2026-03-18 | PR #132 (resolved #127) | -1                   | 36                       |
 | 2026-03-18 | PR #134                 | 0                    | 36                       |
 | 2026-03-19 | PR #145                 | 5                    | 41                       |
+| 2026-03-19 | PR #148 (resolved #146) | -3                   | 41                       |
+| 2026-03-19 | PR #148 (resolved #147) | -2                   | 41                       |
 
 _One row is appended per PR cycle by `/tech-debt-report`. "Cumulative Added" is a gross historical total that only increases; it differs from the Executive Summary net score once items are resolved._
 
@@ -53,9 +55,9 @@ _One row is appended per PR cycle by `/tech-debt-report`. "Cumulative Added" is 
 
 ## Risk Assessment
 
-Elevated risk. Several significant deferred items that introduce coupling or architectural compromise. Recommend a debt reduction sprint before the next major phase.
+Moderate risk. Some deferred workarounds and sub-optimal patterns that will slow future phases if not addressed.
 
-Current debt (score 17) spans three categories. First, architectural coupling in the composables layer: the dual mutation paths (#124, score 3) and the oversized `useMapPersistence` API surface (#125, score 3) introduce maintenance risk as the codebase grows toward Phase 2 game logic. Second, incomplete decomposition: `MapEditorView` still carries calibration and export logic (#126, score 3) that wasn't extracted in the PR #122 refactor pass. Third, schema foundation gaps from PR #145: `HexEditPanel` and `HexMapOverlay` still reference removed fields (#146, score 3), and `EdgeFeature.type` was an open string with no enum constraint (#147, score 2). The two pre-existing elevation architecture items (#111, #112) remain open at low priority.
+Current debt (score 12) is concentrated in two areas. First, architectural coupling in the composables layer: the dual mutation paths (#124, score 3) and the oversized `useMapPersistence` API surface (#125, score 3) introduce maintenance risk as the codebase grows toward Phase 2 game logic. Second, incomplete decomposition: `MapEditorView` still carries calibration and export logic (#126, score 3) that wasn't extracted in the PR #122 refactor pass. The two pre-existing elevation architecture items (#111, #112) remain open at low priority. PR #148 resolved both schema gap items from PR #145 (#146 and #147) in-place, returning net debt to 12.
 
 ---
 
@@ -68,8 +70,6 @@ _Ordered by score descending (ties: newest first). Resolved items are removed._
 | 3     | #126  | Extract `useCalibration` and `useMapExport` from `MapEditorView` | PR #122       | MapEditorView still carries ~378 lines of inline logic despite the extraction of 8 composables. Calibration and export are self-contained concerns that weren't in scope for this PR.                                                  |
 | 3     | #125  | Reduce `useMapPersistence` API surface (23 return values)        | PR #122       | 23 return values with push/pull dialog state mixed into a persistence composable. Reduces reusability and increases caller coupling. Grouping into sub-objects would clarify ownership.                                                |
 | 3     | #124  | Introduce `onHexUpdateBatch` to unify dual mutation paths        | PR #122       | `applyTrace` and `useBulkOperations` bypass `onHexUpdate` for batch efficiency. If `onHexUpdate` gains side effects (undo history, validation), both batch paths silently skip them — maintenance coupling risk.                       |
-| 3     | #146  | Update HexEditPanel + HexMapOverlay to use new schema fields     | PR #145       | Both components still read removed fields (`hex.features[]`, `hex.hexsides`). Edge features and hex features silently render nothing in the editor until fixed. Functional gap blocking use of migrated data.                          |
-| 2     | #147  | Constrain EdgeFeature.type to a z.enum of known types            | PR #145       | `EdgeFeature.type` was an open `z.string()`, allowing unknown type strings to pass schema validation silently. Low immediate impact but undermines the schema as a contract boundary.                                                  |
 | 2     | #111  | Hoist `ElevationSystemControls` to `MapEditorView` sibling       | PR #109       | `CalibrationControls` now passes `elevationSystem` prop and `elevation-system-change` emit through to the child without any logic. Acceptable interim state, but each future extraction compounds the inert API surface on the parent. |
 | 1     | #112  | Consolidate shared form-input CSS across map editor components   | PR #109       | `label` and `input[type='number']` scoped styles are duplicated between `CalibrationControls` and `ElevationSystemControls`. Minor maintenance burden; revisit when a third form-input component is extracted.                         |
 


### PR DESCRIPTION
## Summary
- Removes #146 and #147 from Open Debt Items (both fixed in PR #148)
- Adds resolution rows to Debt Over Time table
- Recalculates Executive Summary: open items 7→5, net score 17→12, PRs tracked 27→28
- Updates Risk Assessment back to Moderate (from Elevated)

## Changes
- `docs/tech-debt/report.md` — debt register update only

## Test plan
- [x] No code changes — docs only

🤖 Generated with [Claude Code](https://claude.com/claude-code)