### PR TITLE
chore: close stale issues + mark tool-panel-framework complete

### DIFF
--- a/conductor/index.md
+++ b/conductor/index.md
@@ -26,7 +26,7 @@ Navigation hub for project context.
 
 | [hex-to-game-id_20260318](./tracks/hex-to-game-id_20260318/index.md) | Extract hexToGameId Helper (Tech Debt #118 + #119) | Complete |
 | [map-schema-foundation_20260319](./tracks/map-schema-foundation_20260319/index.md) | Map Schema Foundation — Data Model + Compass Label Fix (#135, #143) | Complete |
-| [tool-panel-framework_20260319](./tracks/tool-panel-framework_20260319/index.md) | Tool Panel Framework — Shared Architecture (#136) | Pending |
+| [tool-panel-framework_20260319](./tracks/tool-panel-framework_20260319/index.md) | Tool Panel Framework — Shared Architecture (#136) | Complete |
 
 | [map-editor-extraction_20260323](./tracks/map-editor-extraction_20260323/index.md) | MapEditorView Extraction Debt Bundle | Complete |
 | [map-editor-tool-closeout_20260323](./tracks/map-editor-tool-closeout_20260323/index.md) | Map Editor Tool Closeout — Issues #137 #138 #139 #140 #141 #142 | Complete |

--- a/conductor/tracks/tool-panel-framework_20260319/index.md
+++ b/conductor/tracks/tool-panel-framework_20260319/index.md
@@ -1,7 +1,7 @@
 # Track: Tool Panel Framework — Shared Architecture
 
 **ID:** tool-panel-framework_20260319
-**Status:** Pending
+**Status:** Complete
 **GitHub Issue:** #136
 
 ## Documents

--- a/conductor/tracks/tool-panel-framework_20260319/metadata.json
+++ b/conductor/tracks/tool-panel-framework_20260319/metadata.json
@@ -2,16 +2,16 @@
   "id": "tool-panel-framework_20260319",
   "title": "Tool Panel Framework — Shared Architecture",
   "type": "feature",
-  "status": "in_progress",
+  "status": "complete",
   "created": "2026-03-19T00:00:00.000Z",
-  "updated": "2026-03-19T00:00:00.000Z",
+  "updated": "2026-03-23T00:00:00.000Z",
   "githubIssue": 136,
   "phases": {
     "total": 5,
-    "completed": 0
+    "completed": 5
   },
   "tasks": {
     "total": 20,
-    "completed": 0
+    "completed": 20
   }
 }


### PR DESCRIPTION
## Summary
- Close 5 stale GitHub issues already resolved in prior PRs (#153, #155, #160, #164, #167)
- Mark `tool-panel-framework_20260319` conductor track as Complete (GitHub issue #136 was closed; work delivered across PRs #148–#177)
- Update conductor/index.md to reflect Complete status

## Changes
- `conductor/index.md` — tool-panel-framework status: Pending → Complete
- `conductor/tracks/tool-panel-framework_20260319/index.md` — status updated
- `conductor/tracks/tool-panel-framework_20260319/metadata.json` — status/phases/tasks updated

## Test plan
- [x] No code changes — docs/metadata only
- [x] Issue tracker now at 0 open items
- [x] Debt register at 0 open items

🤖 Generated with [Claude Code](https://claude.com/claude-code)