### PR TITLE
fix(review): apply PR #449 team-review findings — aria-hidden, CSS, Space key, loading assert

### DIFF
--- a/client/src/components/UnitCounterLayer.test.js
+++ b/client/src/components/UnitCounterLayer.test.js
@@ -151,4 +151,22 @@ describe('UnitCounterLayer — AT reliability (#434)', () => {
     expect(wrapper.emitted('unit-click')).toBeTruthy();
     expect(wrapper.emitted('unit-click')[0]).toEqual(['unit-a']);
   });
+
+  it('emits unit-click when Space is pressed on the <g> wrapper (#434)', async () => {
+    const wrapper = mount(UnitCounterLayer, {
+      props: { units: [UNIT_A], cellById: BASE_CELL_BY_ID },
+    });
+    const g = wrapper.find('g[role="button"]');
+    await g.trigger('keydown', { key: ' ' });
+    expect(wrapper.emitted('unit-click')).toBeTruthy();
+    expect(wrapper.emitted('unit-click')[0]).toEqual(['unit-a']);
+  });
+
+  it('<image> child carries aria-hidden="true" to prevent double AT announcement (#434)', () => {
+    const wrapper = mount(UnitCounterLayer, {
+      props: { units: [UNIT_A], cellById: BASE_CELL_BY_ID },
+    });
+    const img = wrapper.find('image');
+    expect(img.attributes('aria-hidden')).toBe('true');
+  });
 });

--- a/client/src/components/UnitCounterLayer.vue
+++ b/client/src/components/UnitCounterLayer.vue
@@ -91,11 +91,11 @@ function handleKeydown(event, unitId) {
       role="button"
       tabindex="0"
       class="unit-counter"
-      style="pointer-events: all; cursor: pointer"
       @click.stop="emit('unit-click', entry.unit.id)"
       @keydown="handleKeydown($event, entry.unit.id)"
     >
       <image
+        aria-hidden="true"
         :href="entry.href"
         :x="entry.x"
         :y="entry.y"
@@ -107,6 +107,11 @@ function handleKeydown(event, unitId) {
 </template>
 
 <style scoped>
+.unit-counter {
+  pointer-events: all;
+  cursor: pointer;
+}
+
 .unit-counter:focus-visible {
   outline: 2px solid #ffffff;
   outline-offset: 2px;

--- a/client/src/stores/useGameStore.test.js
+++ b/client/src/stores/useGameStore.test.js
@@ -377,6 +377,8 @@ describe('useGameStore — loadGame double-call guard (#441)', () => {
 
     // First call's state write must have been discarded; game-2 state must survive
     expect(store.gameState.id).toBe('game-2');
+    // loading must be false — the winner's finally ran; the superseded call's finally was guarded
+    expect(store.loading).toBe(false);
   });
 });
 


### PR DESCRIPTION
## Summary

- Applies the 4 findings from the PR #449 team-review that were not included in the squash merge (the review fix commit was on the local branch when `gh pr merge` ran but was not yet pushed to the remote branch)
- All findings were identified during review as fix-in-place; no new debt is introduced

## Changes

- `client/src/components/UnitCounterLayer.vue` — add `aria-hidden="true"` to `<image>` child to prevent AT double-announcement; move `pointer-events: all; cursor: pointer` from inline style to `.unit-counter` scoped CSS
- `client/src/components/UnitCounterLayer.test.js` — add Space key test + `aria-hidden` test for `<g role="button">` pattern
- `client/src/stores/useGameStore.test.js` — add `loading === false` assertion to double-call guard test

## Test plan

- [x] lint passes
- [x] format:check passes
- [x] tests pass (2260 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)