### PR TITLE
chore(conductor): mark m7-special-rules_20260617 complete

### DIFF
--- a/conductor/tracks.md
+++ b/conductor/tracks.md
@@ -140,7 +140,7 @@
 | [x] | m6-debt-closeout_20260615 | M6 Debt Closeout — ROLL_INITIATIVE Side Filter + Sync I/O Memoization (#587 #593) | 2026-06-15 | 2026-06-17 |
 | [x] | pre-m7-debt-sprint-a_20260617 | Pre-M7 Debt Sprint A — Bugs, Security, and High-Score Fixes (#571 #572 #573 #589 #594 #600 #603 #604 #605 #606) | 2026-06-17 | 2026-06-17 |
 | [x] | pre-m7-debt-sprint-b_20260617 | Pre-M7 Debt Sprint B — Test Gaps, Traceability, and Score-1/2 Cleanup (#588 #590 #591 #595 #596 #597 #607 #608 #609 #610 #614 #615 #619 #620 #622 #623) | 2026-06-17 | 2026-06-17 |
-| [ ] | m7-special-rules_20260617 | M7 — Special Rules + Victory Conditions | 2026-06-17 | 2026-06-17 |
+| [x] | m7-special-rules_20260617 | M7 — Special Rules + Victory Conditions | 2026-06-17 | 2026-06-18 |
 | [x] | m7-closeout-m8-ready_20260621 | M7 Closeout — Doc-Sync and M8 Readiness | 2026-06-21 | 2026-06-21 |
 | [x] | pre-m8-debt-sprint_20260621 | Pre-M8 Debt Sprint — Artillery Depletion + Leader Loss (#633 #617) | 2026-06-21 | 2026-06-21 |
 | [x] | ci-env-fix_20260622 | CI Environment Fix — Lockfile Drift + Deploy Workflow Guard | 2026-06-22 | 2026-06-22 |

--- a/conductor/tracks/m7-special-rules_20260617/metadata.json
+++ b/conductor/tracks/m7-special-rules_20260617/metadata.json
@@ -2,18 +2,18 @@
   "id": "m7-special-rules_20260617",
   "title": "M7 — Special Rules + Victory Conditions",
   "type": "feature",
-  "status": "in_progress",
+  "status": "complete",
   "created": "2026-06-17T00:00:00Z",
-  "updated": "2026-06-18T00:35:00Z",
+  "updated": "2026-06-18T02:00:00Z",
   "current_phase": 5,
-  "current_task": "5.9",
+  "current_task": null,
   "phases": {
     "total": 5,
-    "completed": 4
+    "completed": 5
   },
   "tasks": {
     "total": 27,
-    "completed": 32
+    "completed": 27
   },
   "commits": [
     "d77b428: fix(engine): #617 — leaderLossCheckRequired fires on OV attacker SP loss (LOB §9.1a)",
@@ -23,6 +23,10 @@
     "d713576: feat(engine): Phase 2 — interactive RALLY_ROLL action (LOB §6.4 step 3)",
     "d89916d: feat(engine): Phase 3 — artillery actions LIMBER/UNLIMBER/FIRE_ARTILLERY/REPLENISH (LOB §3.6/§8.2/§9.1, SM §3.6)",
     "efc28c9: feat(engine): Phase 4 — end-of-turn accounting (LOB §10.8c, SM §7.0, SM §7.1–7.2)",
-    "fd5c53c: feat(engine): Phase 5 — VP tracking + victory conditions (SM §5.0–5.3, LOB §5.7)"
+    "fd5c53c: feat(engine): Phase 5 — VP tracking + victory conditions (SM §5.0–5.3, LOB §5.7)",
+    "02f2b47: fix(review): apply team-review high-severity findings for PR #632",
+    "45627ee: fix(review): second-pass — random events now fire in production (SM §7.0)",
+    "170797d: docs(tech-debt): add debt report for PR #632 (2026-06-18)",
+    "32029fc: feat(engine): M7 — Special Rules + Victory Conditions (#632) [squash merge]"
   ]
 }


### PR DESCRIPTION
## Summary
- Marks `m7-special-rules_20260617` track as complete in `conductor/tracks.md` and `metadata.json`
- Records squash merge SHA (32029fc) and all review/fix commits in metadata
- Closes issue #343

## Test plan
- [ ] No code changes — conductor metadata only

🤖 Generated with [Claude Code](https://claude.com/claude-code)