### PR TITLE
chore: close out m9-discord-oauth track after PR #701

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,10 +10,10 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 Completed M9 tracks: debt sprint, MOVE action + hex-control wiring, South Mountain map data
 (841 → 2261 hexes, all VP hexes reachable, 100% in-grid coverage — recovered from a forgotten
 git stash, #689; column-64 grid-bounds question resolved, #691; hexside-network visual audit +
-playtest still open in #685; map-data debt sprint closed #693-696). Remaining M9: DO Droplet
-provisioning; Discord OAuth identity (passport + SQLite users table + client auth store) is
-implemented on `feat/m9-discord-oauth`, in review for merge into `master`. See
-`docs/designs/high-level-design.md` §2 for the full milestone history.
+playtest still open in #685; map-data debt sprint closed #693-696); Discord OAuth identity layer
+(passport + SQLite users table + client auth store, session-based — not JWT — via
+`express-session`/`better-sqlite3-session-store`), merged in PR #701. Remaining M9: DO Droplet
+provisioning. See `docs/designs/high-level-design.md` §2 for the full milestone history.
 
 ## Reference Library
 

--- a/conductor/tracks.md
+++ b/conductor/tracks.md
@@ -156,7 +156,7 @@
 | [x] | m9-debt-sprint_20260625 | M9 Debt Sprint — Remaining Open Items (#627 #628 #629 #650 #651 #652 #664) | 2026-06-25 | 2026-06-26 |
 | [ ] | m9-do-deploy_20260625 | M9 DO Deployment — Provision Droplet and Wire deploy.yml (#653) | 2026-06-25 | 2026-06-25 |
 | [x] | m9-move-action_20260625 | M9 MOVE Action — Unit Movement Handler + Hex Control Wiring (#634) | 2026-06-25 | 2026-06-27 |
-| [ ] | m9-discord-oauth_20260625 | M9 Discord OAuth — Identity Layer (#668 #410) | 2026-06-25 | 2026-08-13 |
+| [x] | m9-discord-oauth_20260625 | M9 Discord OAuth — Identity Layer (#668 #410) | 2026-06-25 | 2026-08-13 |
 | [ ] | m9-map-completion_20260625 | M9 Map Completion — South Mountain Hex Digitization (#669, #689) | 2026-06-25 | 2026-08-11 |
 | [x] | move-debt-sprint_20260627 | MOVE Debt Sprint — Path Cost + Partial Moves (#675 #680) | 2026-06-27 | 2026-06-27 |
 | [x] | docs-issue-sync_20260811 | Documentation, Data-Metadata, and Issue-Tracker Sync (#344 #410 #506 #550 #554 #556 #627 #628 #629 #650 #651 #652 #680) | 2026-08-11 | 2026-08-11 |

--- a/conductor/tracks/m9-discord-oauth_20260625/metadata.json
+++ b/conductor/tracks/m9-discord-oauth_20260625/metadata.json
@@ -2,11 +2,11 @@
   "id": "m9-discord-oauth_20260625",
   "title": "M9 Discord OAuth — Identity Layer (#668)",
   "type": "feature",
-  "status": "pending",
+  "status": "complete",
   "created": "2026-06-25T00:00:00Z",
   "updated": "2026-08-13T00:00:00Z",
   "closesIssues": [668, 410],
-  "phases": { "total": 3, "completed": 0 },
-  "tasks": { "total": 14, "completed": 0 },
-  "notes": "Deliberately still 'pending' — this file reflects MASTER's state, which does not yet contain the OAuth implementation. plan.md on feat/m9-discord-oauth is marked Complete (14/14 tasks) because the implementation is done there (Phases 1-3: 36445b3/2082908/d013176, plus a master-merge and a same-day auth-lifecycle fix, and /team-review fixes for #668/#410's original findings). Flip this file to status: complete with tasks.completed: 14 in the same commit that merges the PR — not before. Issue #668 stays open for the same reason."
+  "phases": { "total": 3, "completed": 3 },
+  "tasks": { "total": 14, "completed": 14 },
+  "notes": "Merged to master via PR #701 (2026-08-13). Implementation: Phases 1-3 (36445b3/2082908/d013176), a master-merge bringing 7 weeks of intervening history current, a same-day auth-lifecycle fix (session.regenerate() dropping passport login), and a full /team-review pass that found and fixed 7 High-severity findings (2 genuine security vulnerabilities plus session-lifecycle/identity-authorization gaps). Deferred architecture/test-coverage debt tracked in #698, #699, #700. Issue #668 closed."
 }


### PR DESCRIPTION
## Summary
- Small tracking-only follow-up to PR #701 (M9 Discord OAuth), which merged directly to `master`.
- Flips `metadata.json` to `status: complete` now that the merge has actually happened (it deliberately lagged `plan.md` until this point).
- Updates `conductor/tracks.md` and `CLAUDE.md`'s project-status summary to reflect the merge.

## Changes
- `conductor/tracks/m9-discord-oauth_20260625/metadata.json`
- `conductor/tracks.md`
- `CLAUDE.md`

## Test plan
- [x] Doc/tracking-only change, no code touched — `npm run format:check` confirmed clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)