### PR TITLE
chore(conductor): close out engine-debt-sprint track after PR #705 merge

### DIFF
--- a/conductor/index.md
+++ b/conductor/index.md
@@ -24,7 +24,7 @@ Navigation hub for project context.
 | [map-data-recovery_20260811](./tracks/map-data-recovery_20260811/index.md)             | South Mountain Map Data Recovery — Stash Integration (#689)    | Complete |
 | [map-col64-investigation_20260812](./tracks/map-col64-investigation_20260812/index.md) | South Mountain Map — Column 64 Investigation (#691)            | Complete |
 | [map-data-debt-sprint_20260813](./tracks/map-data-debt-sprint_20260813/index.md)       | Map Data Debt Sprint — Issues #693-696                         | Complete |
-| [engine-debt-sprint_20260813](./tracks/engine-debt-sprint_20260813/index.md)           | Engine Debt Sprint — Issues #676-679, #681                     | Pending  |
+| [engine-debt-sprint_20260813](./tracks/engine-debt-sprint_20260813/index.md)           | Engine Debt Sprint — Issues #676-679, #681                     | Complete |
 
 ## All Tracks
 

--- a/conductor/tracks.md
+++ b/conductor/tracks.md
@@ -163,4 +163,4 @@
 | [x] | map-data-recovery_20260811 | South Mountain Map Data Recovery — Stash Integration (#689) | 2026-08-11 | 2026-08-12 |
 | [x] | map-col64-investigation_20260812 | South Mountain Map — Column 64 Investigation (#691) | 2026-08-12 | 2026-08-12 |
 | [x] | map-data-debt-sprint_20260813 | Map Data Debt Sprint — Issues #693-696 | 2026-08-13 | 2026-08-13 |
-| [ ] | engine-debt-sprint_20260813 | Engine Debt Sprint — Issues #676-679, #681 | 2026-08-13 | 2026-08-13 |
+| [x] | engine-debt-sprint_20260813 | Engine Debt Sprint — Issues #676-679, #681 | 2026-08-13 | 2026-08-13 |

--- a/conductor/tracks/engine-debt-sprint_20260813/index.md
+++ b/conductor/tracks/engine-debt-sprint_20260813/index.md
@@ -1,7 +1,7 @@
 # Track: Engine Debt Sprint — Issues #676-679, #681
 
 **ID:** engine-debt-sprint_20260813
-**Status:** Pending (PR #705 open, awaiting merge)
+**Status:** Complete (PR #705 merged)
 
 ## Documents
 

--- a/conductor/tracks/engine-debt-sprint_20260813/metadata.json
+++ b/conductor/tracks/engine-debt-sprint_20260813/metadata.json
@@ -2,9 +2,9 @@
   "id": "engine-debt-sprint_20260813",
   "title": "Engine Debt Sprint — Issues #676-679, #681",
   "type": "chore",
-  "status": "pending",
+  "status": "complete",
   "created": "2026-08-13T00:00:00Z",
-  "updated": "2026-08-13T00:00:00Z",
+  "updated": "2026-08-13T21:30:00Z",
   "closesIssues": [676, 677, 678, 679, 681],
   "filedIssues": [703, 704, 706],
   "phases": {
@@ -15,5 +15,5 @@
     "total": 32,
     "completed": 32
   },
-  "notes": "PR #705 opened against master, all quality gates green (169 files / 3390 tests), debt register updated (net open debt 17 -> 12). A mandatory targeted second-pass review (Phase 8, triggered because Phase 6's fix touched rules-engine paths) found and fixed a real MEDIUM bug: LIMBER never restored remainingMPs after the artillery-classification fix correctly zeroed it for Unlimbered batteries, blocking limber-then-move entirely. Fixed per a domain-expert ruling (LOB §3.6a: remainingMPs = Limbered allowance - 3 MP cost), verified end-to-end. The symmetric UNLIMBER gap was pre-existing (not caused by this branch) and filed as #706 instead. All four resolvable issues (#676, #677, #678, #681) closed with summaries; #679 closed and replaced by #704; #703 filed as the descoped-scope follow-up for #678. All track work complete; status field will flip to complete once PR #705 merges (awaiting explicit merge instruction)."
+  "notes": "PR #705 merged to master (squash). All quality gates were green (169 files / 3390 tests), debt register updated (net open debt 17 -> 12). A mandatory targeted second-pass review (Phase 8, triggered because Phase 6's fix touched rules-engine paths) found and fixed a real MEDIUM bug: LIMBER never restored remainingMPs after the artillery-classification fix correctly zeroed it for Unlimbered batteries, blocking limber-then-move entirely. Fixed per a domain-expert ruling (LOB §3.6a: remainingMPs = Limbered allowance - 3 MP cost), verified end-to-end. The symmetric UNLIMBER gap was pre-existing (not caused by this branch) and filed as #706 instead. All four resolvable issues (#676, #677, #678, #681) closed with summaries; #679 closed and replaced by #704; #703 filed as the descoped-scope follow-up for #678."
 }


### PR DESCRIPTION
## Summary
- Marks `conductor/tracks/engine-debt-sprint_20260813/` complete now that PR #705 has merged (metadata.json status, index.md status, plan.md phase/task counts were already reconciled pre-merge)
- Flips the track's row in `conductor/tracks.md` and `conductor/index.md` to Complete

## Test plan
- Docs-only change; no code touched.